### PR TITLE
Fix topic creation loop

### DIFF
--- a/src/managers/AuthordDocumentManager.ts
+++ b/src/managers/AuthordDocumentManager.ts
@@ -86,12 +86,15 @@ export default class AuthordDocumentManager extends AbstractDocumentationManager
         }
         this.instances.push(newDocument);
         const title = newDocument['toc-elements'][0].title;
-        let markdownFileExists = await this.createMarkdownFile(newDocument['toc-elements'][0]);
-        // if file name already exists
-        let i = 2
-        while(!markdownFileExists){
+        let fileCreated = await this.createMarkdownFile(newDocument['toc-elements'][0]);
+        // if file already exists, try with incremented title and filename
+        let i = 2;
+        while(!fileCreated){
             newDocument['toc-elements'][0].title = `${title} ${i}`;
-            markdownFileExists = await this.createMarkdownFile(newDocument['toc-elements'][0]);
+            const newFileName = TopicsService.formatTitleAsFilename(newDocument['toc-elements'][0].title);
+            newDocument['toc-elements'][0].topic = newFileName;
+            newDocument['start-page'] = newFileName;
+            fileCreated = await this.createMarkdownFile(newDocument['toc-elements'][0]);
             i += 1;
         }
 

--- a/src/managers/WriterSideDocumentManager.ts
+++ b/src/managers/WriterSideDocumentManager.ts
@@ -198,12 +198,15 @@ export default class WriterSideDocumentManager extends AbstractDocumentationMana
         this.instances.push(newDocument);
 
         const title = newDocument['toc-elements'][0].title;
-        let markdownFileExists = await this.createMarkdownFile(newDocument['toc-elements'][0]);
-        // if file name already exists
-        let i = 2
-        while(!markdownFileExists){
+        let fileCreated = await this.createMarkdownFile(newDocument['toc-elements'][0]);
+        // if file already exists, try with incremented title and filename
+        let i = 2;
+        while(!fileCreated){
             newDocument['toc-elements'][0].title = `${title} ${i}`;
-            markdownFileExists = await this.createMarkdownFile(newDocument['toc-elements'][0]);
+            const newFileName = TopicsService.formatTitleAsFilename(newDocument['toc-elements'][0].title);
+            newDocument['toc-elements'][0].topic = newFileName;
+            newDocument['start-page'] = newFileName;
+            fileCreated = await this.createMarkdownFile(newDocument['toc-elements'][0]);
             i += 1;
         }
         


### PR DESCRIPTION
## Summary
- avoid endless loop when creating new documentation topics

## Testing
- `npm test --silent` *(fails: eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6855dacdb2d083328872653d800f0e98